### PR TITLE
refactor: drop simdjson dependency

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -50,7 +50,7 @@ jobs:
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then compiler=g++; else compiler="clang lld ?exact-name(libclang-rt-dev)"; fi
         apt -y update
-        apt -y install $compiler meson pkg-config cmake libcurl4-openssl-dev libsimdjson-dev libinih-dev git ca-certificates curl gpg gpgv gpg-agent lcov llvm-dev --no-install-recommends
+        apt -y install $compiler meson pkg-config cmake libcurl4-openssl-dev libinih-dev git ca-certificates curl gpg gpgv gpg-agent lcov llvm-dev --no-install-recommends
 
     # For some reason libasan and libubsan are unavaiable on RHEL 9
     - name: Install dependencies (Red Hat)

--- a/.github/workflows/muon.yaml
+++ b/.github/workflows/muon.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y install ${{ matrix.compiler }} ninja-build libpkgconf-dev pkgconf libarchive-dev cmake libcurl4-openssl-dev libsimdjson-dev libinih-dev git ca-certificates --no-install-recommends
+        apt-get -y install ${{ matrix.compiler }} ninja-build libpkgconf-dev pkgconf libarchive-dev cmake libcurl4-openssl-dev libinih-dev git ca-certificates --no-install-recommends
 
     - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cloudflare-ddns is also a library! In fact, the command line tool is fully based
 
 ## Build
 
-libcloudflare-ddns relies on [libcurl](https://curl.se) and [simdjson](https://simdjson.org), while the executable also depends on [inih](https://github.com/benhoyt/inih).
+libcloudflare-ddns relies on [libcurl](https://curl.se) only, while the executable also depends on [inih](https://github.com/benhoyt/inih).
 
 To build the program, you'll need to install a C++ compiler, [Meson](https://mesonbuild.com) and [CMake](https://cmake.org); on Debian and derivatives you can do so with `apt install g++ meson cmake`.
 

--- a/exe/meson.build
+++ b/exe/meson.build
@@ -24,7 +24,6 @@ executable(
 	dependencies: [
 		cloudflare_ddns_dep,
 		libcurl_dep,
-		simdjson_dep,
 		INIReader_dep,
 		extra_deps
 	],

--- a/include/ddns/cloudflare-ddns.h
+++ b/include/ddns/cloudflare-ddns.h
@@ -202,8 +202,8 @@ DDNS_NODISCARD DDNS_PUB ddns_error ddns_get_zone_id_raw(
  * it is an A or AAAA record. The three values are written in record_ip,
  * record_id, and aaaa respectively. If their _size is too small,
  * the function returns DDNS_ERROR_USAGE; if some other error occurs, it
- * returns DDNS_ERROR_GENERIC. Since Cloudflare's API returns data in JSON
- * form, the function uses simdjson to parse that data as fast as possible.
+ * returns DDNS_ERROR_GENERIC.
+ *
  * Since the function has to access the response of the HTTP GET request it
  * has to create and manage its own cURL handle internally, and this hurts
  * a bit in terms of performance. If you prefer to control your own cURL
@@ -247,11 +247,12 @@ DDNS_NODISCARD DDNS_PUB ddns_error ddns_get_record_raw(
  * address of a given A/AAAA record, identified by record_id, to the one
  * passed as new_ip. It manages its own cURL handle under the hood, and
  * writes the IP that Cloudflare received and set in record_ip, if
- * successful, parsed using simdjson. If the size of the out parameter is
- * smaller than the size of the IP set by Cloudflare, or if the length of
- * the zone id is not DDNS_ZONE_ID_LENGTH, or if the length of the record
- * name is greater than DDNS_RECORD_NAME_MAX_LENGTH, the function returns
- * DDNS_ERROR_USAGE; on any other error, it returns DDNS_ERROR_GENERIC.
+ * successful. If the size of the out parameter is smaller than the size
+ * of the IP set by Cloudflare, or if the length of the zone id is not
+ * DDNS_ZONE_ID_LENGTH, or if the length of the record name is greater than
+ * DDNS_RECORD_NAME_MAX_LENGTH, the function returns DDNS_ERROR_USAGE; on
+ * any other error, it returns DDNS_ERROR_GENERIC.
+ *
  * This function is thread safe, but it creates and destroys a cURL handle
  * by itself, which may be slow. If you want faster performance by reusing
  * the same handle you can look into update_record_raw().

--- a/meson.build
+++ b/meson.build
@@ -66,61 +66,6 @@ if not libcurl_dep.found()
 	endif
 endif
 
-simdjson_dep = dependency('simdjson', version: '>=0.9.0', required: false)
-
-# Old Meson versions are unable to extract the version from simdjson
-simdjson_dep_found = simdjson_dep.found()
-if simdjson_dep_found
-	simdjson_version = compiler.get_define(
-		'SIMDJSON_VERSION',
-		dependencies: simdjson_dep,
-		prefix: '#include <simdjson.h>'
-	)
-	simdjson_dep_found = simdjson_version.version_compare('>=0.9.0')
-endif
-
-if not simdjson_dep_found
-	if not get_option('muon')
-		if compiler.get_id() == 'clang' and compiler.get_linker_id() != 'ld.lld'
-			warning('When using Clang you must also use LLD. You can use it by setting the CXX_LD environment variable to lld')
-		endif
-		cmake = import('cmake')
-		if meson.version().version_compare('>=0.55.0')
-			simdjson_options = cmake.subproject_options()
-			simdjson_options.add_cmake_defines({
-				'CMAKE_BUILD_TYPE': get_option('buildtype'),
-				'CMAKE_POSITION_INDEPENDENT_CODE': get_option('b_staticpic'),
-				'CMAKE_INTERPROCEDURAL_OPTIMIZATION': get_option('b_lto'),
-				'CMAKE_POLICY_DEFAULT_CMP0069': 'NEW',
-				'MSVC_RUNTIME_LIBRARY': 'MultiThreaded',
-				'BUILD_SHARED_LIBS': false,
-				'SIMDJSON_DEVELOPER_MODE': false,
-				'SIMDJSON_WINDOWS_DLL': false,
-				'SIMDJSON_USING_WINDOWS_DYNAMIC_LIBRARY': false,
-				'SIMDJSON_DISABLE_DEPRECATED_API': true,
-				'SIMDJSON_ENABLE_FUZZING': false
-			})
-			simdjson_options.set_install(false)
-			if compiler.get_argument_syntax() == 'msvc'
-				simdjson_options.append_compile_args('c',   '/MT')
-				simdjson_options.append_compile_args('cpp', '/MT')
-			endif
-			simdjson_dep = cmake.subproject('simdjson', options: simdjson_options).dependency('simdjson')
-		else
-			simdjson_dep = cmake.subproject('simdjson').dependency('simdjson')
-		endif
-	else
-		# muon can't find dependencies using CMake, yet
-		simdjson_dep = declare_dependency(
-			compile_args: '-DSIMDJSON_THREADS_ENABLED=1',
-			dependencies: [
-				compiler.find_library('simdjson'),
-				dependency('threads')
-			]
-		)
-	endif
-endif
-
 extra_args = []
 
 if host_machine.system() == 'windows'
@@ -147,7 +92,6 @@ libcloudflare_ddns = library(
 	cpp_args: extra_args,
 	dependencies: [
 		libcurl_dep,
-		simdjson_dep,
 		extra_deps
 	],
 	extra_files: 'include'/'ddns'/'cloudflare-ddns.h',

--- a/subprojects/simdjson.wrap
+++ b/subprojects/simdjson.wrap
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: 2022 Andrea Pappacoda
-#
-# SPDX-License-Identifier: FSFAP
-
-[wrap-file]
-source_url = https://github.com/simdjson/simdjson/archive/refs/tags/v1.0.2.tar.gz
-source_filename = simdjson-1.0.2.tar.gz
-directory = simdjson-1.0.2
-source_hash = 46d5995488de76ae61f1c3bcff445a9085c8d34f6cbc9bf0422a99c6d98a002c


### PR DESCRIPTION
cloudflare-ddns now doesn't depend anymore on simdjson, and JSON "parsing" is done manually with a really simple function which just looks at a JSON string and extracts a string value given a key, which is sufficient for cloudflare-ddns' needs.

Dropping the simdjson dependency makes the project way easier and faster to compile, likely less resource intensive since no fancy SIMD instructions are executed, and more portable.