### PR TITLE
feat: support updating multiple A records

### DIFF
--- a/exe/config.ini
+++ b/exe/config.ini
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+# SPDX-FileCopyrightText: 2025 Toni Melisma
 #
 # SPDX-License-Identifier: FSFAP
 
 [ddns]
 api_token = token
-record_name = name
+record_name = www.example.com,example.com

--- a/exe/main.cpp
+++ b/exe/main.cpp
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+ * SPDX-FileCopyrightText: 2025 Toni Melisma
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -21,10 +22,12 @@ namespace std {
 #include <optional> /* std::optional */
 #include <string> /* std::string */
 #include <string_view> /* std::string_view */
+#include <vector> /* std::vector */
 
 #include <INIReader.h>
 #include <ddns/cloudflare-ddns.h>
 #include "paths.hpp"
+#include "utils.hpp"
 
 struct static_buffer {
 	static constexpr std::size_t capacity {CURL_MAX_WRITE_SIZE / 2}; // typical requests are smaller than 2000 bytes
@@ -49,11 +52,6 @@ static std::size_t write_data(
 	// null-terminate the buffer (so that it can be used as a C string)
 	// data->buffer[data->size] = '\0';
 	return /*size **/ count;
-}
-
-static void curl_cleanup(CURL** curl) {
-	curl_easy_cleanup(*curl);
-	curl_global_cleanup();
 }
 
 /*
@@ -133,164 +131,200 @@ int main(const int argc, char* argv[]) {
 		return EXIT_FAILURE;
 	}
 
-	/* Make sure to avoid path traversal vulnerabilities */
-	if (record_name.find('/') != std::string::npos
-		|| record_name.find(std::filesystem::path::preferred_separator) != std::string::npos) {
-		std::fputs("Record names cannot contain path separators!\n", stderr);
+	const std::vector<std::string> record_names {parse_record_names(record_name)};
+
+	if (record_names.empty()) {
+		std::fputs("No valid record names provided.\n", stderr);
 		return EXIT_FAILURE;
 	}
 
 	curl_global_init(CURL_GLOBAL_DEFAULT);
 
-	CURL* curl_handle {curl_easy_init()};
-	static_buffer dns_response;
-
-	curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
-	curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1L);
-	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_data);
-	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &dns_response);
-	curl_easy_setopt(curl_handle, CURLOPT_TCP_FASTOPEN, 1L);
-	curl_easy_setopt(curl_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
-	curl_easy_setopt(curl_handle, CURLOPT_DEFAULT_PROTOCOL, "https");
-
-	ddns_error error = DDNS_ERROR_OK;
-	// +1 because of '\0'
-	std::array<char, DDNS_ZONE_ID_LENGTH + 1> zone_id;
-
-	const std::string cache_path = std::string{cache_dir} + record_name;
-
-	// Here the cache file is opened twice, the first time read-only and
-	// the second time write-only. This is because if the filesystem is
-	// mounted read-only I'm still able to read the cache, if available.
-	const bool cache_miss = std::ifstream{cache_path, std::ios::binary}
-		.read(zone_id.data(), zone_id.size())
-		.fail();
-
-	if (cache_miss || ddns_strnlen(zone_id.data(), zone_id.size()) != DDNS_ZONE_ID_LENGTH) {
-		error = ddns_search_zone_id(api_token.c_str(), record_name.c_str(), zone_id.size(), zone_id.data());
-		if (error) {
-			std::fputs("Error getting the Zone ID\n", stderr);
-			curl_cleanup(&curl_handle);
-			return EXIT_FAILURE;
-		}
-		// This also writes '\0'
-		std::ofstream{cache_path, std::ios::binary}
-			.write(zone_id.data(), zone_id.size());
-	}
-
-	error = ddns_get_record_raw(api_token.c_str(), zone_id.data(), record_name.c_str(), &curl_handle);
-	if (error) {
-		std::fprintf(stderr,
-			"Error getting DNS record info\n"
-			"API response: %.*s\n", static_cast<int>(dns_response.size), dns_response.buffer);
-		curl_cleanup(&curl_handle);
-		return EXIT_FAILURE;
-	}
-
-	// The first element contains the IPv4 address, while the second
-	// contains the IPv6 one.
-	constexpr const char* ipv_c_str[2] = {"IPv4", "IPv6"};
-	constexpr const char* type_c_str[2] = {"A", "AAAA"};
-	std::string_view record_ids[2];
-	std::string_view record_ips[2];
-	std::size_t records_count = 0;
-
-	const char* id_pos = dns_response.buffer;
-	const char* type_pos = dns_response.buffer;
-	const char* dns_ip_pos = dns_response.buffer;
-	while (true) {
-		const std::optional id = get_json_value(std::string_view(id_pos, dns_response.size - (id_pos - dns_response.buffer)), "\"id\"");
-		if (!id.has_value()) {
-			break;
-		}
-		id_pos = id->data();
-
-		const std::optional type = get_json_value(std::string_view(type_pos, dns_response.size - (type_pos - dns_response.buffer)), "\"type\"");
-		if (!type.has_value()) {
-			break;
-		}
-		type_pos = type->data();
-
-		const std::optional dns_ip = get_json_value(std::string_view(dns_ip_pos, dns_response.size - (dns_ip_pos - dns_response.buffer)), "\"content\"");
-		if (!dns_ip.has_value()) {
-			break;
-		}
-		dns_ip_pos = dns_ip->data();
-
-		if (type == "A") {
-			record_ids[0] = *id;
-			record_ips[0] = *dns_ip;
-			records_count++;
-		}
-		else if (type == "AAAA") {
-			record_ids[1] = *id;
-			record_ips[1] = *dns_ip;
-			records_count++;
-		}
-	}
-
-	if (records_count == 0) {
-		std::fprintf(stderr, "%s doesn't point to any A or AAAA record\n", record_name.c_str());
-		curl_cleanup(&curl_handle);
-		return EXIT_FAILURE;
-	}
-	else if (records_count > 2) {
-		std::fprintf(stderr, "%s points to more than two records, things might not work as expected\n", record_name.c_str());
-	}
+	int return_code = EXIT_SUCCESS;
 
 	std::array<char, DDNS_IP_ADDRESS_MAX_LENGTH> local_ips[2];
+	std::array<bool, 2> local_ip_fetched = {false, false};
 
-	unsigned int local_ips_count = 0;
+	for (const std::string& current_record_name : record_names) {
+		// Create a fresh curl handle for each record to avoid state pollution
+		// (e.g., CURLOPT_CUSTOMREQUEST from a PATCH persisting into subsequent GETs)
+		CURL* curl_handle {curl_easy_init()};
+		static_buffer dns_response;
 
-	for (unsigned int i = 0; i < 2; i++) {
-		if (record_ips[i].empty()) {
+		curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
+		curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1L);
+		curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, write_data);
+		curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &dns_response);
+		curl_easy_setopt(curl_handle, CURLOPT_TCP_FASTOPEN, 1L);
+		curl_easy_setopt(curl_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
+		curl_easy_setopt(curl_handle, CURLOPT_DEFAULT_PROTOCOL, "https");
+		/* Make sure to avoid path traversal vulnerabilities */
+		if (current_record_name.find('/') != std::string::npos
+			|| current_record_name.find(std::filesystem::path::preferred_separator) != std::string::npos) {
+			std::fprintf(stderr, "[%s] Record names cannot contain path separators!\n", current_record_name.c_str());
+			curl_easy_cleanup(curl_handle);
+			return_code = EXIT_FAILURE;
 			continue;
 		}
-		error = ddns_get_local_ip(i, local_ips[i].size(), local_ips[i].data());
+
+		ddns_error error = DDNS_ERROR_OK;
+		// +1 because of '\0'
+		std::array<char, DDNS_ZONE_ID_LENGTH + 1> zone_id;
+
+		const std::string cache_path = std::string{cache_dir} + current_record_name;
+
+		// Here the cache file is opened twice, the first time read-only and
+		// the second time write-only. This is because if the filesystem is
+		// mounted read-only I'm still able to read the cache, if available.
+		const bool cache_miss = std::ifstream{cache_path, std::ios::binary}
+			.read(zone_id.data(), zone_id.size())
+			.fail();
+
+		if (cache_miss || ddns_strnlen(zone_id.data(), zone_id.size()) != DDNS_ZONE_ID_LENGTH) {
+			error = ddns_search_zone_id(api_token.c_str(), current_record_name.c_str(), zone_id.size(), zone_id.data());
+			if (error) {
+				std::fprintf(stderr, "[%s] Error getting the Zone ID\n", current_record_name.c_str());
+				curl_easy_cleanup(curl_handle);
+				return_code = EXIT_FAILURE;
+				continue;
+			}
+			// This also writes '\0'
+			std::ofstream{cache_path, std::ios::binary}
+				.write(zone_id.data(), zone_id.size());
+		}
+
+		dns_response.size = 0;
+		error = ddns_get_record_raw(api_token.c_str(), zone_id.data(), current_record_name.c_str(), &curl_handle);
 		if (error) {
-			std::fprintf(stderr, "Error getting the local %s address\n", ipv_c_str[i]);
+			std::fprintf(stderr,
+				"[%s] Error getting DNS record info\n"
+				"API response: %.*s\n",
+				current_record_name.c_str(),
+				static_cast<int>(dns_response.size),
+				dns_response.buffer
+			);
+			curl_easy_cleanup(curl_handle);
+			return_code = EXIT_FAILURE;
 			continue;
 		}
-		local_ips_count++;
 
-		if (local_ips[i].data() != record_ips[i]) {
-			// record_ids isn't NULL-terminated since it's just a view of
-			// dns_response, so I need to create a NULL-termiated C string
-			// manually. record_ids.length() and DDNS_RECORD_ID_LENGTH are
-			// the same.
-			char id[DDNS_RECORD_ID_LENGTH + 1];
-			std::memcpy(id, record_ids[i].data(), DDNS_RECORD_ID_LENGTH);
-			id[DDNS_RECORD_ID_LENGTH] = '\0';
+		// The first element contains the IPv4 address, while the second
+		// contains the IPv6 one.
+		constexpr const char* ipv_c_str[2] = {"IPv4", "IPv6"};
+		constexpr const char* type_c_str[2] = {"A", "AAAA"};
+		std::string_view record_ids[2];
+		std::string_view record_ips[2];
+		std::size_t records_count = 0;
 
-			dns_response.size = 0;
-			if (ddns_update_record_raw(
-				api_token.c_str(),
-				zone_id.data(),
-				id,
-				local_ips[i].data(),
-				&curl_handle
-			) != DDNS_ERROR_OK) {
-				std::fprintf(stderr, "Error updating the %s record\n", type_c_str[i]);
-				curl_cleanup(&curl_handle);
-				return EXIT_FAILURE;
+		const char* id_pos = dns_response.buffer;
+		const char* type_pos = dns_response.buffer;
+		const char* dns_ip_pos = dns_response.buffer;
+		while (true) {
+			const std::optional id = get_json_value(std::string_view(id_pos, dns_response.size - (id_pos - dns_response.buffer)), "\"id\"");
+			if (!id.has_value()) {
+				break;
 			}
+			id_pos = id->data();
 
-			const std::optional new_ip = get_json_value(std::string_view(dns_response.buffer, dns_response.size), "\"content\"");
-			if (!new_ip.has_value()) {
-				fputs("Something went very wrong\n", stderr);
-				return 1;
+			const std::optional type = get_json_value(std::string_view(type_pos, dns_response.size - (type_pos - dns_response.buffer)), "\"type\"");
+			if (!type.has_value()) {
+				break;
 			}
+			type_pos = type->data();
 
-			std::printf("New %s: %.*s\n", ipv_c_str[i], static_cast<int>(new_ip->length()), new_ip->data());
+			const std::optional dns_ip = get_json_value(std::string_view(dns_ip_pos, dns_response.size - (dns_ip_pos - dns_response.buffer)), "\"content\"");
+			if (!dns_ip.has_value()) {
+				break;
+			}
+			dns_ip_pos = dns_ip->data();
+
+			if (type == "A") {
+				record_ids[0] = *id;
+				record_ips[0] = *dns_ip;
+				records_count++;
+			}
+			else if (type == "AAAA") {
+				record_ids[1] = *id;
+				record_ips[1] = *dns_ip;
+				records_count++;
+			}
 		}
-		else {
-			std::printf("The %s record is up to date\n", type_c_str[i]);
+
+		if (records_count == 0) {
+			std::fprintf(stderr, "[%s] doesn't point to any A or AAAA record\n", current_record_name.c_str());
+			curl_easy_cleanup(curl_handle);
+			return_code = EXIT_FAILURE;
+			continue;
 		}
+		else if (records_count > 2) {
+			std::fprintf(stderr, "[%s] points to more than two records, things might not work as expected\n", current_record_name.c_str());
+		}
+
+		unsigned int local_ips_count = 0;
+
+		for (unsigned int i = 0; i < 2; i++) {
+			if (record_ips[i].empty()) {
+				continue;
+			}
+			if (!local_ip_fetched[i]) {
+				error = ddns_get_local_ip(i, local_ips[i].size(), local_ips[i].data());
+				if (error) {
+					std::fprintf(stderr, "[%s] Error getting the local %s address\n", current_record_name.c_str(), ipv_c_str[i]);
+					continue;
+				}
+				local_ip_fetched[i] = true;
+			}
+			local_ips_count++;
+
+			if (local_ips[i].data() != record_ips[i]) {
+				// record_ids isn't NULL-terminated since it's just a view of
+				// dns_response, so I need to create a NULL-termiated C string
+				// manually. record_ids.length() and DDNS_RECORD_ID_LENGTH are
+				// the same.
+				char id[DDNS_RECORD_ID_LENGTH + 1];
+				std::memcpy(id, record_ids[i].data(), DDNS_RECORD_ID_LENGTH);
+				id[DDNS_RECORD_ID_LENGTH] = '\0';
+
+				dns_response.size = 0;
+				if (ddns_update_record_raw(
+					api_token.c_str(),
+					zone_id.data(),
+					id,
+					local_ips[i].data(),
+					&curl_handle
+				) != DDNS_ERROR_OK) {
+					std::fprintf(stderr, "[%s] Error updating the %s record\n", current_record_name.c_str(), type_c_str[i]);
+					return_code = EXIT_FAILURE;
+					continue;
+				}
+
+				const std::optional new_ip = get_json_value(std::string_view(dns_response.buffer, dns_response.size), "\"content\"");
+				if (!new_ip.has_value()) {
+					std::fprintf(stderr, "[%s] Something went very wrong\n", current_record_name.c_str());
+					return_code = EXIT_FAILURE;
+					continue;
+				}
+
+				std::printf("[%s] New %s: %.*s\n",
+					current_record_name.c_str(),
+					ipv_c_str[i],
+					static_cast<int>(new_ip->length()),
+					new_ip->data()
+				);
+			}
+			else {
+				std::printf("[%s] The %s record is up to date\n", current_record_name.c_str(), type_c_str[i]);
+			}
+		}
+
+		if (local_ips_count == 0) {
+			return_code = EXIT_FAILURE;
+		}
+
+		curl_easy_cleanup(curl_handle);
 	}
 
-	curl_cleanup(&curl_handle);
+	curl_global_cleanup();
 
-	if (local_ips_count == 0) {
-		return EXIT_FAILURE;
-	}
+	return return_code;
 }

--- a/exe/utils.hpp
+++ b/exe/utils.hpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Toni Melisma
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+inline std::vector<std::string> parse_record_names(std::string_view input) {
+	std::vector<std::string> records;
+	std::string_view::size_type pos = 0;
+
+	while (pos != std::string_view::npos) {
+		std::string_view::size_type next_pos = input.find(',', pos);
+		std::string_view current_record_name = input.substr(pos, next_pos - pos);
+
+		// Trim whitespace
+		const auto first = current_record_name.find_first_not_of(" \t");
+		if (first == std::string_view::npos) {
+			// Empty or all-whitespace record, skip
+			if (next_pos == std::string_view::npos) {
+				break;
+			}
+			pos = next_pos + 1;
+			continue;
+		}
+		const auto last = current_record_name.find_last_not_of(" \t");
+		current_record_name = current_record_name.substr(first, (last - first) + 1);
+
+		records.emplace_back(current_record_name);
+
+		if (next_pos != std::string_view::npos) {
+			pos = next_pos + 1;
+		}
+		else {
+			pos = next_pos;
+		}
+	}
+	return records;
+}

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+# SPDX-FileCopyrightText: 2025 Toni Melisma
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -6,5 +7,6 @@ option('executable',       type: 'boolean', value: true,  description: 'Build th
 option('tests',            type: 'boolean', value: false, description: 'Build tests')
 option('test_api_token',   type: 'string', description: 'API token to use for tests')
 option('test_zone_id',     type: 'string', description: 'Zone ID to use for tests')
-option('test_record_name', type: 'string', description: 'Record name to use for tests')
-option('muon',             type: 'boolean', value: false, description: 'Enable if building with muon')
+option('test_record_name',   type: 'string', description: 'Record name to use for tests')
+option('test_record_name_2', type: 'string', description: 'Second record name to use for multi-record tests')
+option('muon',               type: 'boolean', value: false, description: 'Enable if building with muon')

--- a/tests/credentials.hpp.in
+++ b/tests/credentials.hpp.in
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+ * SPDX-FileCopyrightText: 2025 Toni Melisma
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -7,6 +8,7 @@
 #pragma once
 #include <string_view>
 
-inline constexpr const char* const test_api_token   = "@test_api_token@";
-inline constexpr const char* const test_zone_id     = "@test_zone_id@";
-inline constexpr const char* const test_record_name = "@test_record_name@";
+inline constexpr const char* const test_api_token     = "@test_api_token@";
+inline constexpr const char* const test_zone_id       = "@test_zone_id@";
+inline constexpr const char* const test_record_name   = "@test_record_name@";
+inline constexpr const char* const test_record_name_2 = "@test_record_name_2@";

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2021 Andrea Pappacoda
+# SPDX-FileCopyrightText: 2025 Toni Melisma
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -6,9 +7,10 @@ credentials_hpp = configure_file(
 	input: 'credentials.hpp.in',
 	output: 'credentials.hpp',
 	configuration: {
-		'test_api_token':   get_option('test_api_token'),
-		'test_zone_id':     get_option('test_zone_id'),
-		'test_record_name': get_option('test_record_name')
+		'test_api_token':     get_option('test_api_token'),
+		'test_zone_id':       get_option('test_zone_id'),
+		'test_record_name':   get_option('test_record_name'),
+		'test_record_name_2': get_option('test_record_name_2')
 	}
 )
 
@@ -41,7 +43,9 @@ tests = [
 	'get_local_ip',
 	'get_record',
 	'search_zone_id',
-	'update_record'
+	'update_record',
+	'test_parsing',
+	'update_multiple_records'
 ]
 
 foreach test : tests

--- a/tests/test_parsing.cpp
+++ b/tests/test_parsing.cpp
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Toni Melisma
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "../exe/utils.hpp"
+#include "common.hpp"
+#include <string>
+#include <vector>
+
+int main() {
+	"parse_record_names"_test = [] {
+		should("parse single record") = [] {
+			auto result = parse_record_names("example.com");
+			expect(result.size() == 1_ul);
+			expect(result[0] == "example.com");
+		};
+
+		should("parse two records") = [] {
+			auto result = parse_record_names("example.com,sub.example.com");
+			expect(result.size() == 2_ul);
+			expect(result[0] == "example.com");
+			expect(result[1] == "sub.example.com");
+		};
+
+		should("parse records with spaces") = [] {
+			auto result = parse_record_names(" example.com , sub.example.com ");
+			expect(result.size() == 2_ul);
+			expect(result[0] == "example.com");
+			expect(result[1] == "sub.example.com");
+		};
+
+		should("ignore empty records") = [] {
+			auto result = parse_record_names("example.com,,sub.example.com");
+			expect(result.size() == 2_ul);
+			expect(result[0] == "example.com");
+			expect(result[1] == "sub.example.com");
+		};
+
+		should("ignore whitespace-only records") = [] {
+			auto result = parse_record_names("example.com, ,sub.example.com");
+			expect(result.size() == 2_ul);
+			expect(result[0] == "example.com");
+			expect(result[1] == "sub.example.com");
+		};
+
+		should("handle trailing comma") = [] {
+			auto result = parse_record_names("example.com,");
+			expect(result.size() == 1_ul);
+			expect(result[0] == "example.com");
+		};
+
+		should("handle leading comma") = [] {
+			auto result = parse_record_names(",example.com");
+			expect(result.size() == 1_ul);
+			expect(result[0] == "example.com");
+		};
+
+		should("handle trailing comma with spaces") = [] {
+			auto result = parse_record_names("example.com, ");
+			expect(result.size() == 1_ul);
+			expect(result[0] == "example.com");
+		};
+
+		should("handle leading comma with spaces") = [] {
+			auto result = parse_record_names(" ,example.com");
+			expect(result.size() == 1_ul);
+			expect(result[0] == "example.com");
+		};
+	};
+}

--- a/tests/update_multiple_records.cpp
+++ b/tests/update_multiple_records.cpp
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Toni Melisma
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "common.hpp"
+#include "../exe/utils.hpp"
+#include <array>
+#include <string>
+#include <vector>
+
+int main() {
+	/**
+	 * Test updating a single record to verify backward compatibility.
+	 * This mirrors the existing update_record test but uses the
+	 * multi-record loop pattern.
+	 */
+	"update_single_record"_test = [] {
+		std::vector<std::string> records = {test_record_name};
+		expect(records.size() == 1_ul);
+
+		for (const auto& record : records) {
+			std::array<char, DDNS_IP_ADDRESS_MAX_LENGTH> local_ip;
+			expect(eq(ddns_get_local_ip(false, local_ip.size(), local_ip.data()), DDNS_ERROR_OK));
+
+			std::array<char, DDNS_ZONE_ID_LENGTH + 1> zone_id;
+			expect(eq(ddns_search_zone_id(test_api_token, record.c_str(), zone_id.size(), zone_id.data()), DDNS_ERROR_OK));
+
+			std::array<char, DDNS_IP_ADDRESS_MAX_LENGTH> record_ip;
+			std::array<char, DDNS_RECORD_ID_LENGTH + 1> record_id;
+			bool aaaa;
+			expect(eq(ddns_get_record(
+				test_api_token,
+				zone_id.data(),
+				record.c_str(),
+				record_ip.size(), record_ip.data(),
+				record_id.size(), record_id.data(),
+				&aaaa
+			), DDNS_ERROR_OK));
+
+			expect(eq(ddns_update_record(
+				test_api_token,
+				zone_id.data(),
+				record_id.data(),
+				local_ip.data(),
+				record_ip.size(), record_ip.data()
+			), DDNS_ERROR_OK));
+
+			expect(eq(
+				std::string_view{local_ip.data()},
+				std::string_view{record_ip.data()}
+			));
+		}
+	};
+
+	/**
+	 * Test updating two different records in sequence.
+	 */
+	"update_two_records"_test = [] {
+		std::vector<std::string> records = {test_record_name, test_record_name_2};
+		expect(records.size() == 2_ul);
+
+		int success_count = 0;
+		for (const auto& record : records) {
+			std::array<char, DDNS_IP_ADDRESS_MAX_LENGTH> local_ip;
+			ddns_error err = ddns_get_local_ip(false, local_ip.size(), local_ip.data());
+			if (err != DDNS_ERROR_OK) {
+				continue;
+			}
+
+			std::array<char, DDNS_ZONE_ID_LENGTH + 1> zone_id;
+			err = ddns_search_zone_id(test_api_token, record.c_str(), zone_id.size(), zone_id.data());
+			if (err != DDNS_ERROR_OK) {
+				continue;
+			}
+
+			std::array<char, DDNS_IP_ADDRESS_MAX_LENGTH> record_ip;
+			std::array<char, DDNS_RECORD_ID_LENGTH + 1> record_id;
+			bool aaaa;
+			err = ddns_get_record(
+				test_api_token,
+				zone_id.data(),
+				record.c_str(),
+				record_ip.size(), record_ip.data(),
+				record_id.size(), record_id.data(),
+				&aaaa
+			);
+			if (err != DDNS_ERROR_OK) {
+				continue;
+			}
+
+			err = ddns_update_record(
+				test_api_token,
+				zone_id.data(),
+				record_id.data(),
+				local_ip.data(),
+				record_ip.size(), record_ip.data()
+			);
+			if (err == DDNS_ERROR_OK) {
+				success_count++;
+			}
+		}
+		expect(success_count == 2_i);
+	};
+
+	/**
+	 * Test that an invalid record fails gracefully without crashing.
+	 * The loop should continue processing after encountering an error.
+	 */
+	"update_one_valid_one_invalid_record"_test = [] {
+		std::vector<std::string> records = {test_record_name, "nonexistent.invalid.domain.example"};
+
+		int success_count = 0;
+		int failure_count = 0;
+
+		for (const auto& record : records) {
+			std::array<char, DDNS_ZONE_ID_LENGTH + 1> zone_id;
+			ddns_error err = ddns_search_zone_id(test_api_token, record.c_str(), zone_id.size(), zone_id.data());
+
+			if (err == DDNS_ERROR_OK) {
+				success_count++;
+			}
+			else {
+				failure_count++;
+			}
+		}
+
+		// First record should succeed, second should fail
+		expect(success_count == 1_i);
+		expect(failure_count == 1_i);
+	};
+
+	/**
+	 * Test that an empty record list is handled correctly.
+	 */
+	"update_empty_record_list"_test = [] {
+		std::vector<std::string> records = {};
+		expect(records.empty());
+
+		int iterations = 0;
+		for (const auto& record : records) {
+			(void)record;
+			iterations++;
+		}
+		expect(iterations == 0_i);
+	};
+
+	/**
+	 * Test that parse_record_names correctly handles a single record.
+	 */
+	"parse_single_record"_test = [] {
+		auto result = parse_record_names(test_record_name);
+		expect(result.size() == 1_ul);
+		expect(result[0] == test_record_name);
+	};
+}


### PR DESCRIPTION
- Allow comma-separated record names in config and CLI
- Refactor main loop to handle multiple records
- Add parsing utility and unit tests
- Move path-traversal check inside loop to validate each record
- Add real integration tests for update_multiple_records
- Update config.ini example